### PR TITLE
Fix app name in string resources

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">My Application</string>
+    <string name="app_name">モバイルアプリ開発A</string>
 </resources>


### PR DESCRIPTION
The application name was updated to "モバイルアプリ開発A" in the `strings.xml` file.